### PR TITLE
Change window title to include folder name

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -52,7 +52,7 @@ namespace QuickLook.Plugin.FolderViewer
             _panel = new FolderInfoPanel(path);
 
             context.ViewerContent = _panel;
-            context.Title = $"{Path.GetDirectoryName(path)}";
+            context.Title = $"{Path.GetFileName(path)}";
 
             context.IsBusy = false;
         }


### PR DESCRIPTION
Currently, the window title will show the path of the previewed folder, without its name. This would make it hard to go through different folders under the same path.